### PR TITLE
Add testing for .Net 8.0

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore src
     - name: Build

--- a/README.md
+++ b/README.md
@@ -319,14 +319,15 @@ Assemblies are provided targeting the following:
 
 To build Ookii.CommandLine, make sure you have the following installed:
 
-- [Microsoft .Net 7.0 SDK](https://dotnet.microsoft.com/download) or later
+- [Microsoft .Net 8.0 SDK](https://dotnet.microsoft.com/download) or later
 
 To build the library, tests and samples, simply use the `dotnet build` command in the `src`
 directory. You can run the unit tests using `dotnet test`. The tests should pass on all platforms
 (Windows and Linux have been tested).
 
-The tests are built and run for .Net 7.0, .Net 6.0, and .Net Framework 4.8. Running the .Net
-Framework tests on a non-Windows platform may require the use of [Mono](https://www.mono-project.com/).
+The tests are built and run for .Net 8,.0, .Net 7.0, .Net 6.0, and .Net Framework 4.8. Running the
+.Net Framework tests on a non-Windows platform may require the use of
+[Mono](https://www.mono-project.com/).
 
 Ookii.BinarySize uses a strongly-typed resources file, which will not update correctly unless the
 `Resources.resx` file is edited with [Microsoft Visual Studio](https://visualstudio.microsoft.com/).

--- a/src/Ookii.BinarySize.Test/Ookii.BinarySize.Test.csproj
+++ b/src/Ookii.BinarySize.Test/Ookii.BinarySize.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>11.0</LangVersion>

--- a/src/Ookii.BinarySize/Ookii.BinarySize.csproj
+++ b/src/Ookii.BinarySize/Ookii.BinarySize.csproj
@@ -52,7 +52,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <PackageReference Include="System.Memory" Version="4.5.5" Condition="'$(TargetFramework)'=='netstandard2.0'" />
-    <PackageReference Include="System.Text.Json" Version="7.0.3" Condition="'$(TargetFramework)'=='netstandard2.0' Or '$(TargetFramework)'=='netstandard2.1'" />
+    <PackageReference Include="System.Text.Json" Version="8.0.0" Condition="'$(TargetFramework)'=='netstandard2.0' Or '$(TargetFramework)'=='netstandard2.1'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/Configuration/Configuration.csproj
+++ b/src/Samples/Configuration/Configuration.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
At this time, I don't believe it's necessary to update Ookii.CommandLine itself to .Net 8, as the .Net 7 version of the library will work in .Net 8 projects. However, the unit tests add a .Net 8.0 target to ensure everything works correctly.